### PR TITLE
 test: limit jacoco agent to test scope

### DIFF
--- a/aliyun-java-sdk-core/pom.xml
+++ b/aliyun-java-sdk-core/pom.xml
@@ -134,6 +134,7 @@
             <artifactId>org.jacoco.agent</artifactId>
             <version>0.8.12</version>
             <classifier>runtime</classifier>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.ini4j</groupId>


### PR DESCRIPTION
Test dependency `org.jacoco:org.jacoco.agent` is currently considered a compile dependency.

This PR limits it to the `test` scope.